### PR TITLE
Reporting the position of the last valid token

### DIFF
--- a/metalua/grammar/generator.lua
+++ b/metalua/grammar/generator.lua
@@ -149,17 +149,32 @@ end
 -- Generate a tracable parsing error (not implemented yet)
 -------------------------------------------------------------------------------
 function M.parse_error(lx, fmt, ...)
-   local li = lx:lineinfo_left()
+   local inf = lx:lineinfo_error()
    local file, line, column, offset, positions
-   if li then
+   local p_line, p_column
+   if inf then
+      local li = inf.last
       file, line, column, offset = li.source, li.line, li.column, li.offset
-      positions = { first = li, last = li }
+      local first = inf.first
+      positions = { first = first, last = li }
+
+      local facing = inf.first.facing
+      if facing.line >= first.line and
+          facing.column >= first.column then
+         -- special case when there's no previous token
+         p_line, p_column = first.line, first.column
+      else
+         p_line, p_column = facing.line, facing.column
+      end
    else
-      line, column, offset = -1, -1, -1
+      line, column, offset, p_line, p_column = -1, -1, -1, -1, -1
    end
 
    local msg  = string.format("line %i, char %i: "..fmt, line, column, ...)
    if file and file~='?' then msg = "file "..file..", "..msg end
+   local prev_token = string.format("facing: line %i, char %i", p_line, p_column)
+   msg = string.format("%s\n%s", msg, prev_token)
+
 
    local src = lx.src
    if offset>0 and src then

--- a/metalua/grammar/generator.lua
+++ b/metalua/grammar/generator.lua
@@ -159,9 +159,16 @@ function M.parse_error(lx, fmt, ...)
       positions = { first = first, last = li }
 
       local facing = inf.first.facing
+      -- in case of a parse error, the consumed token usually facing the one
+      -- that caused the problem is the last valid one, allowing us to point
+      -- to the exact location where the invalid token starts
+      -- there are exceptions to this, identified so far:
+      -- * there's just one token yet
+      -- * there are comment(s) after the last valid token
       if facing.line >= first.line and
-          facing.column >= first.column then
-         -- special case when there's no previous token
+          facing.column >= first.column
+          or facing.comments
+      then
          p_line, p_column = first.line, first.column
       else
          p_line, p_column = facing.line, facing.column

--- a/metalua/grammar/generator.lua
+++ b/metalua/grammar/generator.lua
@@ -159,15 +159,22 @@ function M.parse_error(lx, fmt, ...)
       positions = { first = first, last = li }
 
       local facing = inf.first.facing
+      local no_invalid_comment = function(comments)
+         for _, c in ipairs(comments) do
+            if c[1]:match("%[%[") then
+               return false
+            end
+         end
+         return true
+      end
       -- in case of a parse error, the consumed token usually facing the one
       -- that caused the problem is the last valid one, allowing us to point
       -- to the exact location where the invalid token starts
       -- there are exceptions to this, identified so far:
       -- * there's just one token yet
       -- * there are comment(s) after the last valid token
-      if facing.line >= first.line and
-          facing.column >= first.column
-          or facing.comments
+      if (facing.line >= first.line and facing.column >= first.column) or
+          (facing.comments and no_invalid_comment(facing.comments))
       then
          p_line, p_column = first.line, first.column
       else

--- a/metalua/grammar/lexer.lua
+++ b/metalua/grammar/lexer.lua
@@ -511,6 +511,7 @@ function lexer :next (n)
       -- TODO: is this used anywhere? I think not.  a.lineinfo.last may be nil.
       --self.lastline = a.lineinfo.last.line
    end
+   self.lineinfo_consumed = a.lineinfo
    self.lineinfo_last_consumed = a.lineinfo.last
    return a
 end
@@ -572,6 +573,10 @@ end
 
 function lexer :lineinfo_left()
    return self.lineinfo_last_consumed
+end
+
+function lexer :lineinfo_error()
+   return self.lineinfo_consumed
 end
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
This PR aims to provide the location info of the token facing the one where a parse error occured.
To this end, another line of text is added to the parse error, in the form of
> facing: line ?, char ?

The implementation has been tested against a set of cases originally from [LuaMinify][lm], with more [corner cases][own] added as they come up during manual testing.

[lm]: https://github.com/stravant/LuaMinify/blob/master/tests/test_parser.lua
[own]: https://github.com/aldum/loveputer/blob/sprint09/tests/parser_inputs.lua#L153